### PR TITLE
Add option to use `display: none` instead of `hidden`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ When initializing `transitionHiddenElement`, there are two required parameters a
 const simpleFader = transitionHiddenElement({
   element: document.querySelector('.js-simple-fade'), // Required
   visibleClass: 'is-shown', // Required
-  hideMode: 'transitionend', // Optional — defaults to `'transitionend'`
+  waitMode: 'transitionend', // Optional — defaults to `'transitionend'`
   timeoutDuration: null // Optional — defaults to `null`
 });
 ```
@@ -95,9 +95,9 @@ const simpleFader = transitionHiddenElement({
 
 `visibleClass` is the class that will be added when showing our `element`. Adding the class should trigger a transition on our `element` or its child elements.
 
-### hideMode `{String}`
+### waitMode `{String}`
 
-`hideMode` determines when the utility should re-apply the `hidden` attribute. It defaults to `transitionend` but has a few options:
+`waitMode` determines when the utility should re-apply the `hidden` attribute when hiding. It defaults to `transitionend` but has a few options:
 
 1. `transitionend` — Wait for the `element`'s `transitionend` event to fire. This works if the element has a transition that will be triggered by removing the `visibleClass`.
 2. `timeout` — Wait a certain number of milliseconds. This is useful when your `element` is not the only element transitioning. For example, if removing your `visibleClass` triggers transitions on child elements, then you should use this option. When using this option be sure to pass in a number for the `timeoutDuration` parameter.
@@ -107,7 +107,7 @@ Regardless of which setting you choose, it will be converted to `immediate` if a
 
 ### timeoutDuration `{Number}`
 
-When using the `timeout` option for `hideMode` you should be sure to pass in the length of the timeout in milliseconds.
+When using the `timeout` option for `waitMode` you should be sure to pass in the length of the timeout in milliseconds.
 
 ## Object Methods
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A JavaScript utility to help you use CSS transitions when showing and hiding ele
 
 ## Why was this created?
 
-To [properly hide elements from all users including screen reader users](https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/), elements should be hidden using the `hidden` attribute. However, this prevents elements from being transitioned with CSS. If you'd like to use CSS transitions to show and hide these elements you'll need to use JavaScript to do so. This utility wraps that JavaScript into a small, easy-to-use module. 
+To [properly hide elements from all users including screen reader users](https://cloudfour.com/thinks/see-no-evil-hidden-content-and-accessibility/), elements should be hidden using the `hidden` attribute or `display: none;`. However, this prevents elements from being transitioned with CSS. If you'd like to use CSS transitions to show and hide these elements you'll need to use JavaScript to do so. This utility wraps that JavaScript into a small, easy-to-use module. 
 
 ## How it Works
 
@@ -17,7 +17,7 @@ To [properly hide elements from all users including screen reader users](https:/
 
 To allow transitions when showing an element the utility performs a few steps:
 
-1. Remove the `hidden` attribute.
+1. Remove the `hidden` attribute (or `display: none;`).
 2. Trigger a browser reflow.
 3. Apply a class to trigger the transition(s).
 
@@ -27,7 +27,7 @@ To allow transitions when hiding an element the utility performs a few steps:
 
 1. Remove a class to trigger the transition(s). 
 2. Wait for the transition to complete, or wait for a timeout to complete. (Depending on initialization settings.)
-3. Add the `hidden` attribute.
+3. Add the `hidden` attribute (or `display: none;`).
 
 ### Animated Children
 
@@ -84,12 +84,14 @@ const simpleFader = transitionHiddenElement({
   visibleClass: 'is-shown', // Required
   waitMode: 'transitionend', // Optional — defaults to `'transitionend'`
   timeoutDuration: null // Optional — defaults to `null`
+  hideMode: 'hidden', // Optional — defaults to `'hidden'`
+  displayValue: null // Optional — defaults to `'block'`
 });
 ```
 
 ### element `{HTMLElement}`
 
-`element` should be the primary element we're showing and hiding. It will be the element that we'll be adding and removing classes and the `hidden` attribute from.
+`element` should be the primary element we're showing and hiding. It will be the element that we'll be adding and removing classes and the `hidden` attribute (or `display: none;`) from.
 
 ### visibleClass `{String}`
 
@@ -97,7 +99,7 @@ const simpleFader = transitionHiddenElement({
 
 ### waitMode `{String}`
 
-`waitMode` determines when the utility should re-apply the `hidden` attribute when hiding. It defaults to `transitionend` but has a few options:
+`waitMode` determines when the utility should re-apply the `hidden` attribute (or `display: none;`) when hiding. It defaults to `transitionend` but has a few options:
 
 1. `transitionend` — Wait for the `element`'s `transitionend` event to fire. This works if the element has a transition that will be triggered by removing the `visibleClass`.
 2. `timeout` — Wait a certain number of milliseconds. This is useful when your `element` is not the only element transitioning. For example, if removing your `visibleClass` triggers transitions on child elements, then you should use this option. When using this option be sure to pass in a number for the `timeoutDuration` parameter.
@@ -109,17 +111,28 @@ Regardless of which setting you choose, it will be converted to `immediate` if a
 
 When using the `timeout` option for `waitMode` you should be sure to pass in the length of the timeout in milliseconds.
 
+### hideMode `{String}`
+
+`hideMode` determines whether elements are hidden by applying the `hidden` attribute, or using CSS's `display: none;`. It has two options
+
+1. `hidden` — use the `hidden` attribute (this is the default)
+1. `display` — use CSS's `display: none;`
+
+### displayValue `{String}`
+
+When using the `display` option for `hideMode`, this option determines what `display` should be set to when showing elements. e.g. `block`, `inline`, `inline-block`, etc.
+
 ## Object Methods
 
 After initializing your `transitionHiddenElement` it will return an object with a few methods.
 
 ### show()
 
-Shows your `element`. Removes `hidden`, triggers a document reflow, and applies your `visibleClass`.
+Shows your `element`. Removes `hidden`  (or `display: none;`), triggers a document reflow, and applies your `visibleClass`.
 
 ### hide()
 
-Hides your `element`. Removes your `visibleClass` and adds `hidden`.
+Hides your `element`. Removes your `visibleClass` and adds `hidden` (or `display: none;`).
 
 ### toggle()
 
@@ -127,7 +140,7 @@ Toggles the visibility of your `element`. Shows it if it's hidden and hides it i
 
 ### isHidden()
 
-Returns the current hidden status of your `element`. It returns `true` if the element has the `hidden` attribute or is missing the `visibleClass`.
+Returns the current hidden status of your `element`. It returns `true` if the element has the `hidden` attribute, is `display: none;` or is missing the `visibleClass`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A JavaScript utility to help you use CSS transitions when showing and hiding ele
 ## Demos
 
 1. [An example](https://codepen.io/phebert/pen/yLybwWY) showing this library in action.
-2. [A more complex example](https://codepen.io/phebert/pen/yLybwWY) showing using this library with staggered child transitions and toggling.
+2. [A more complex example](https://codepen.io/phebert/pen/QWwONMy) showing using this library with staggered child transitions and toggling.
 
 ## Why was this created?
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Transition Hidden Element
 
-A JavaScript utility to help you use CSS transitions when showing and hiding elements with the `hidden` attribute.
+A JavaScript utility to help you use CSS transitions when showing and hiding elements with the `hidden` attribute or `display: none;`.
 
 ## Demos
 

--- a/cypress/integration/fade_in_out_display.js
+++ b/cypress/integration/fade_in_out_display.js
@@ -1,0 +1,116 @@
+const opacityIsTransitioning = element => {
+  const opacity = window.getComputedStyle(element).getPropertyValue('opacity');
+  return opacity > 0 && opacity < 1;
+};
+
+describe('Fade In and Out using Display', function() {
+  it('Showing', function() {
+    cy.visit('/').then(function(contextWindow) {
+      cy.log('Check initial state');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'none');
+
+      cy.log('Trigger `show()`');
+      cy.get('.js-show-fade-in-out-display').click();
+
+      cy.log('Check that display has been toggled');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'block');
+
+      cy.log('Wait for transition to begin');
+      cy.wait(100);
+
+      cy.log('Confirm element is transitioning');
+      cy.wrap({ transitioning: opacityIsTransitioning })
+        .invoke(
+          'transitioning',
+          contextWindow.document.querySelector('.js-fade-in-out-display')
+        )
+        .should('be', true);
+    });
+  });
+
+  it('Hiding', function() {
+    cy.visit('/').then(function(contextWindow) {
+      cy.log('Override initial state');
+      cy.get('.js-fade-in-out-display').then(fader => {
+        fader[0].style.display = 'block';
+        fader[0].classList.add('is-shown');
+      });
+
+      cy.log('Confirm state override was successful');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'block');
+
+      cy.log('Trigger `hide()`');
+      cy.get('.js-hide-fade-in-out-display').click();
+
+      cy.log('Wait for transition to begin');
+      cy.wait(100);
+
+      cy.log('Confirm element is transitioning');
+      cy.wrap({ transitioning: opacityIsTransitioning })
+        .invoke(
+          'transitioning',
+          contextWindow.document.querySelector('.js-fade-in-out-display')
+        )
+        .should('be', true);
+
+      cy.log('Confirm `display` is not toggled during the transition');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'block');
+
+      cy.log('Wait for transition to end');
+      cy.wait(300);
+
+      cy.log('Confirm `display` is toggled when the transition ends');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'none');
+    });
+  });
+
+  it('Toggling', function() {
+    cy.visit('/').then(function(contextWindow) {
+      cy.log('Check initial state');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'none');
+
+      cy.log('Trigger `toggle()` (show)');
+      cy.get('.js-toggle-fade-in-out-display').click();
+
+      cy.log('Confirm display has been toggled');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'block');
+
+      cy.log('Wait for transition to begin');
+      cy.wait(100);
+
+      cy.log('Confirm element is transitioning');
+      cy.wrap({ transitioning: opacityIsTransitioning })
+        .invoke(
+          'transitioning',
+          contextWindow.document.querySelector('.js-fade-in-out-display')
+        )
+        .should('be', true);
+
+      cy.log('Wait for transition to end');
+      cy.wait(300);
+
+      cy.log('Trigger another `toggle()` (hide)');
+      cy.get('.js-toggle-fade-in-out-display').click();
+
+      cy.log('Wait for transition to begin');
+      cy.wait(100);
+
+      cy.log('Confirm element is transitioning');
+      cy.wrap({ transitioning: opacityIsTransitioning })
+        .invoke(
+          'transitioning',
+          contextWindow.document.querySelector('.js-fade-in-out-display')
+        )
+        .should('be', true);
+
+      cy.log('Confirm display is not toggled during the transition');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'block');
+
+      cy.log('Wait for transition to end');
+      cy.wait(300);
+
+      cy.log('Confirm display is toggled when the transition ends');
+      cy.get('.js-fade-in-out-display').should('have.css', 'display').and('eq', 'none');
+    });
+  });
+});

--- a/cypress/integration/timeout_spec.js
+++ b/cypress/integration/timeout_spec.js
@@ -3,7 +3,7 @@ const opacityIsTransitioning = element => {
   return opacity > 0 && opacity < 1;
 };
 
-describe('Fade With Timeout HideMode', function() {
+describe('Fade With Timeout waitMode', function() {
   it('Showing', function() {
     cy.visit('/').then(function(contextWindow) {
       cy.log('Check initial state');

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -19,6 +19,8 @@ document
     simpleFader.toggle();
   });
 
+
+
 const fadeIn = transitionHiddenElement({
   element: document.querySelector('.js-fade-in'),
   visibleClass: 'is-shown',
@@ -36,6 +38,8 @@ document.querySelector('.js-hide-fade-in').addEventListener('click', () => {
 document.querySelector('.js-toggle-fade-in').addEventListener('click', () => {
   fadeIn.toggle();
 });
+
+
 
 const fadeOutTimeout = transitionHiddenElement({
   element: document.querySelector('.js-fade-out-timeout'),
@@ -60,4 +64,31 @@ document
   .querySelector('.js-toggle-fade-out-timeout')
   .addEventListener('click', () => {
     fadeOutTimeout.toggle();
+  });
+
+
+
+const fadeInOutDisplay = transitionHiddenElement({
+  element: document.querySelector('.js-fade-in-out-display'),
+  visibleClass: 'is-shown',
+  hideMode: 'display',
+  displayValue: 'block'
+});
+
+document
+  .querySelector('.js-show-fade-in-out-display')
+  .addEventListener('click', () => {
+    fadeInOutDisplay.show();
+  });
+
+document
+  .querySelector('.js-hide-fade-in-out-display')
+  .addEventListener('click', () => {
+    fadeInOutDisplay.hide();
+  });
+
+document
+  .querySelector('.js-toggle-fade-in-out-display')
+  .addEventListener('click', () => {
+    fadeInOutDisplay.toggle();
   });

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -22,7 +22,7 @@ document
 const fadeIn = transitionHiddenElement({
   element: document.querySelector('.js-fade-in'),
   visibleClass: 'is-shown',
-  hideMode: 'immediate'
+  waitMode: 'immediate'
 });
 
 document.querySelector('.js-show-fade-in').addEventListener('click', () => {
@@ -40,7 +40,7 @@ document.querySelector('.js-toggle-fade-in').addEventListener('click', () => {
 const fadeOutTimeout = transitionHiddenElement({
   element: document.querySelector('.js-fade-out-timeout'),
   visibleClass: 'is-shown',
-  hideMode: 'timeout',
+  waitMode: 'timeout',
   timeoutDuration: 300
 });
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -39,7 +39,7 @@ const simpleFader = transitionHiddenElement({
 const fadeIn = transitionHiddenElement({
   element: document.querySelector('.js-fade-in'),
   visibleClass: 'is-shown',
-  hideMode: 'immediate'
+  waitMode: 'immediate'
 });
       </code>
     </pre>
@@ -59,7 +59,7 @@ const fadeIn = transitionHiddenElement({
 const fadeOutTimeout = transitionHiddenElement({
   element: document.querySelector('.js-fade-out-timeout'),
   visibleClass: 'is-shown',
-  hideMode: 'timeout',
+  waitMode: 'timeout',
   timeoutDuration: 300
 });
       </code>

--- a/demo/index.html
+++ b/demo/index.html
@@ -72,6 +72,27 @@ const fadeOutTimeout = transitionHiddenElement({
     <p class="simple-fade js-fade-out-timeout" hidden>I should fade in and out. After fading out, <code>hidden</code> should be applied to me.</p>
 
 
+    <h2>Fade In and Out with `display: none;`</code></h2>
+
+
+    <pre>
+      <code>
+const fadeInOutDisplay = transitionHiddenElement({
+  element: document.querySelector('.js-fade-in-out-display'),
+  visibleClass: 'is-shown',
+  hideMode: 'display',
+  displayValue: 'block'
+});
+      </code>
+    </pre>
+
+    <button class="js-show-fade-in-out-display">Show</button>
+    <button class="js-hide-fade-in-out-display">Hide</button>
+    <button class="js-toggle-fade-in-out-display">Toggle</button>
+
+    <p class="simple-fade js-fade-in-out-display" style="display: none;">I should fade in and out. After fading out, <code>display: none;</code> should be applied to me.</p>
+
+
 
     <script src="demo.js"></script>
   </body>

--- a/src/index.js
+++ b/src/index.js
@@ -15,12 +15,21 @@
  *  `'timeout'`, and `'immediate'` (to hide immediately)
  * @param  {Number} opts.timeoutDuration — If `waitMode` is set to `'timeout'`,
  *  then this determines the length of the timeout.
+ * @param {String} opts.hideMode - Determine how the library should hide
+ *  elements. The options are `hidden` (use the `hidden` attribute), and
+ *  `display` (use the CSS `display` property). Defaults to `hidden`
+ * @param {String} opts.displayValue - When using the `display` `hideMode`, this
+ *  parameter determines what the CSS `display` property should be set to when
+ *  the element is shown. e.g. `block`, `inline`, `inline-block`. Defaults to
+ *  `block`.
  */
 export function transitionHiddenElement({
   element,
   visibleClass,
   waitMode = 'transitionend',
-  timeoutDuration
+  timeoutDuration,
+  hideMode = 'hidden',
+  displayValue = 'block'
 }) {
   if (waitMode === 'timeout' && typeof timeoutDuration !== 'number') {
     console.error(`
@@ -46,11 +55,27 @@ export function transitionHiddenElement({
     // Confirm `transitionend` was called on  our `element` and didn't bubble
     // up from a child element.
     if (e.target === element) {
-      element.setAttribute('hidden', true);
+      applyHiddenAttributes();
 
       element.removeEventListener('transitionend', listener);
     }
   };
+
+  const applyHiddenAttributes = () => {
+    if(hideMode === 'display') {
+      element.style.display = 'none';
+    } else {
+      element.setAttribute('hidden', true);
+    }
+  }
+
+  const removeHiddenAttributes = () => {
+    if(hideMode === 'display') {
+      element.style.display = displayValue;
+    } else {
+      element.removeAttribute('hidden');
+    }
+  }
 
   return {
     /**
@@ -71,7 +96,7 @@ export function transitionHiddenElement({
         clearTimeout(this.timeout);
       }
 
-      element.removeAttribute('hidden');
+      removeHiddenAttributes();
 
       /**
        * Force a browser re-paint so the browser will realize the
@@ -90,10 +115,10 @@ export function transitionHiddenElement({
         element.addEventListener('transitionend', listener);
       } else if (waitMode === 'timeout') {
         this.timeout = setTimeout(() => {
-          element.setAttribute('hidden', true);
+          applyHiddenAttributes();
         }, timeoutDuration);
       } else {
-        element.setAttribute('hidden', true);
+        applyHiddenAttributes();
       }
 
       // Add this class to trigger our animation
@@ -121,9 +146,11 @@ export function transitionHiddenElement({
        */
       const hasHiddenAttribute = element.getAttribute('hidden') !== null;
 
+      const isDisplayNone = element.style.display === 'none';
+
       const hasVisibleClass = [...element.classList].includes(visibleClass);
 
-      return hasHiddenAttribute || !hasVisibleClass;
+      return hasHiddenAttribute || isDisplayNone || !hasVisibleClass;
     },
 
     // A placeholder for our `timeout`

--- a/src/index.js
+++ b/src/index.js
@@ -10,21 +10,21 @@
  * @param {Object} opts - Our options element, destructed into its properties
  * @param {HTMLElement} opts.element - The element we're showing and hiding
  * @param {String} opts.visibleClass - The class to add when showing the element
- * @param {String} opts.hideMode - Determine how the library should check that
+ * @param {String} opts.waitMode - Determine how the library should check that
  *  hiding transitions are complete. The options are `'transitionEnd'`,
  *  `'timeout'`, and `'immediate'` (to hide immediately)
- * @param  {Number} opts.timeoutDuration — If `hideMode` is set to `'timeout'`,
+ * @param  {Number} opts.timeoutDuration — If `waitMode` is set to `'timeout'`,
  *  then this determines the length of the timeout.
  */
 export function transitionHiddenElement({
   element,
   visibleClass,
-  hideMode = 'transitionend',
+  waitMode = 'transitionend',
   timeoutDuration
 }) {
-  if (hideMode === 'timeout' && typeof timeoutDuration !== 'number') {
+  if (waitMode === 'timeout' && typeof timeoutDuration !== 'number') {
     console.error(`
-      When calling transitionHiddenElement with hideMode set to timeout,
+      When calling transitionHiddenElement with waitMode set to timeout,
       you must pass in a number for timeoutDuration.
     `);
 
@@ -35,7 +35,7 @@ export function transitionHiddenElement({
   // Ideally transitions will be disabled in CSS, which means we should not wait
   // before adding `hidden`.
   if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-    hideMode = 'immediate';
+    waitMode = 'immediate';
   }
 
   /**
@@ -86,9 +86,9 @@ export function transitionHiddenElement({
      * Hide the element
      */
     hide() {
-      if (hideMode === 'transitionend') {
+      if (waitMode === 'transitionend') {
         element.addEventListener('transitionend', listener);
-      } else if (hideMode === 'timeout') {
+      } else if (waitMode === 'timeout') {
         this.timeout = setTimeout(() => {
           element.setAttribute('hidden', true);
         }, timeoutDuration);


### PR DESCRIPTION
This adds additional parameters so the library can be used with `display: none;` as well as `hidden.

It adds tests and demos for this, as well as documentation.

This renames `hideMode` to `waitMode`, so is a breaking change.