### PR TITLE
Stop caching the Cypress binary and merge CI into one job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,15 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  cypress-run:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7.0.1
-      - name: Cypress run
-        uses: cypress-io/github-action@v7.4.3
-        with:
-          start: npm start
   ci:
     runs-on: ubuntu-latest
     steps:
@@ -35,3 +26,14 @@ jobs:
         run: npm ci
       - name: Run linter 👀
         run: npm run lint:check
+      # `install: false` skips the action's own dependency install, which also
+      # skips its npm and Cypress binary caches. Both are keyed on the whole
+      # package-lock.json hash with no prefix fallback, so any dependency bump
+      # invalidates the 213 MB binary cache even though the binary is unchanged.
+      # Restoring it saves ~3s, saving it costs ~4.4s, and it almost always
+      # missed here — a net loss that consumed 77% of the repo's cache budget.
+      - name: Cypress run 🧪
+        uses: cypress-io/github-action@v7.4.3
+        with:
+          install: false
+          start: npm start


### PR DESCRIPTION
## Overview

This PR addresses a CI cache that was costing more time than it saved. `cypress-io/github-action` builds both of its cache keys from the full `package-lock.json` hash and matches on that key exactly, with no prefix fallback. The Cypress binary only changes when Cypress does, so keying it on the whole lockfile meant every unrelated dependency bump minted a fresh 213 MB entry. Branch scoping doubled the waste — a Renovate PR missed and saved into the pull request's own cache scope, then the merge to `main` couldn't read that scope and saved a second copy. The result was 5,322 MB, 77% of this repository's 10 GB cache budget, for a cache that almost never hit.

Measuring recent runs, restoring the binary takes ~2.4–3.9s, saving it takes ~4.4s, and simply downloading it from Cypress's CDN takes ~5.6–6.5s. A hit saved about 3 seconds; a miss cost about 4.4. Since 26 of the last 30 commits changed the lockfile, the cache was a net loss of roughly 3.4 seconds per run. This is the same conclusion we reached for Playwright browser caching in `cloudfour.com-patterns`, though for a different reason: Cypress's single large archive really does restore quickly, but the download it replaces is short enough that the mandatory save on every miss swamps the benefit.

The action exposes no key or toggle for its binary cache, so `install: false` is the only way to opt out — which means the dependency install moves into the job itself. That in turn made the two-job split redundant, since both jobs were already running a full `npm ci`. Folding them together also drops a wasted Cypress binary download: the lint-only job pulled the ~120 MB binary on every run and never used it. Expect roughly 44% fewer runner minutes and a cache footprint closer to 850 MB.

One deliberate trade-off: linting no longer runs in parallel with the tests, so a lint failure now stops the run before Cypress executes. Lint takes about 4 seconds and failures are trivially fixed, so fast feedback seemed worth more than always getting both results at once.

## Screenshots

## Testing

- [ ] Open the **Checks** tab on this PR. There should be a single check named **ci**, where previously there were two (**ci** and **cypress-run**).
- [ ] Open that check's log and confirm it installs dependencies once, then runs the linter, then runs the Cypress tests — all four spec files should pass.
- [ ] In the same log, expand the Cypress step. It should report `Skipping install because install parameter is false`, and there should be no cache upload at the end of the step.
- [ ] Visit the repository's **Actions → Caches** page. After this PR runs, no new `cypress-linux-x64-…` entry should appear for it. The existing entries will age out on their own under GitHub's 7-day expiry.
- [ ] Compare the total run time against a recent run on `main` — it should finish in about the same wall-clock time or slightly faster, while using noticeably less runner time overall.

---

Closes #711
