### PR TITLE
Extend shared Renovate preset

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,4 +1,4 @@
 {
-  "extends": ["config:recommended", ":automergeMinor", ":pinVersions"],
-  "minimumReleaseAge": "3 days"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>cloudfour/renovate-config:library"]
 }


### PR DESCRIPTION
## Overview

This repo's `.renovaterc.json` was byte-identical to eleven other Cloud Four repos, which meant every config change Scott wanted everywhere had to be hand-applied across a dozen-plus files — something that's happened three or four times now. We've set up [`cloudfour/renovate-config`](https://github.com/cloudfour/renovate-config) as a shared preset source, and this replaces the local config with a one-line `extends`.

This repo extends the `library` preset rather than the default because it publishes to npm. The `library` preset is the default plus one rule keeping `peerDependencies` and `engines` as ranges instead of pinning them. That rule is a no-op here today, since this package declares neither field — but the shared config pins exact versions globally, so the day someone adds an `engines` entry it would be silently pinned and break installs for every consumer.

This is the pilot for the migration, so it's landing first and on its own to confirm preset resolution works before the remaining repos follow.

## Screenshots

## Testing

- [ ] Open `.renovaterc.json` on this branch — it should contain only a `$schema` line and a single `extends` entry pointing at `local>cloudfour/renovate-config:library`
- [ ] After merging, open the **Dependency Dashboard** issue in this repo and wait for Renovate to run (or click the checkbox at the bottom to request an immediate run)
- [ ] The dashboard should render normally with no configuration-error banner. A red "Config Validation" or "Preset Not Found" warning at the top would mean the preset failed to resolve
- [ ] Confirm Renovate still behaves as before: any new patch or minor update PR should be set to auto-merge, and updates should not appear until three days after the release

---

Part of cloudfour/renovate-config#1