### PR TITLE
Update @cloudfour/eslint-config to v26.1.0 and drop local overrides

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -9,48 +9,6 @@ const config = [
   ...cloudFourConfig,
   pluginCypress.configs.recommended,
   {
-    rules: {
-      'unicorn/expiring-todo-comments': 'off',
-    },
-  },
-  {
-    // The `jsdoc` plugin is only registered for JavaScript, so these have to be
-    // scoped. A bare `rules` block would also apply them to the HTML, CSS and
-    // JSON that xo now lints, and ESLint fails on the unknown plugin.
-    files: ['**/*.{js,cjs,mjs}'],
-    rules: {
-      // A tag's description runs until the next tag, and leading whitespace on
-      // the continuation lines is stripped before it is parsed, so indenting
-      // them changes nothing about the output. It only makes it easier to see
-      // where one `@param` ends and the next begins. Require the indent rather
-      // than forbid it, and keep `check-indentation` on for the cases that do
-      // signal a mistake, such as an indented tag line.
-      'jsdoc/check-indentation': ['error', { allowIndentedSections: true }],
-      'jsdoc/check-line-alignment': ['error', 'never', { wrapIndent: '  ' }],
-    },
-  },
-  {
-    files: ['package.json'],
-    rules: {
-      // Switching to `exports` or `"type": "module"` would change what this
-      // package exposes to existing consumers, so both belong in a deliberate
-      // major release rather than in lint cleanup.
-      'package-json/prefer-exports': 'off',
-      'package-json/prefer-type-module': 'off',
-      // This is a browser library. It never runs in Node, so there is no
-      // meaningful Node version to declare.
-      'package-json/require-engines': 'off',
-    },
-  },
-  {
-    files: ['demo/**/*.html'],
-    rules: {
-      // The demo page is served locally by `npm start` and is never linked to
-      // from anywhere, so there is nothing for Open Graph tags to describe.
-      '@html-eslint/require-open-graph-protocol': 'off',
-    },
-  },
-  {
     files: ['**/*.cy.js'],
     ...pluginJest.configs['flat/recommended'],
     rules: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.2",
       "license": "MIT",
       "devDependencies": {
-        "@cloudfour/eslint-config": "26.0.0",
+        "@cloudfour/eslint-config": "26.1.0",
         "@rollup/plugin-babel": "7.1.0",
         "@rollup/plugin-node-resolve": "16.0.3",
         "browser-sync": "3.0.4",
@@ -262,9 +262,9 @@
       }
     },
     "node_modules/@cloudfour/eslint-config": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@cloudfour/eslint-config/-/eslint-config-26.0.0.tgz",
-      "integrity": "sha512-eWueuMkri16sKgoTjMqljhbHJXbTtF5/b3wXbjZP5pkIo1J0OvVTjH4rBGYYAAVsa9VrCZOKePw8idI3tBjw6A==",
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@cloudfour/eslint-config/-/eslint-config-26.1.0.tgz",
+      "integrity": "sha512-mCXGYt45jJb9XxXfZyX+nD3HMfSdIj6cey7RRuNevfjGvKyB2bpUGAu76Znmg2yXkfalN7yj4795B2xPrQ9mGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "css"
   ],
   "devDependencies": {
-    "@cloudfour/eslint-config": "26.0.0",
+    "@cloudfour/eslint-config": "26.1.0",
     "@rollup/plugin-babel": "7.1.0",
     "@rollup/plugin-node-resolve": "16.0.3",
     "browser-sync": "3.0.4",


### PR DESCRIPTION
## Overview

When we upgraded to `@cloudfour/eslint-config` v26 in #720, we added four override blocks to this repo to turn off rules that were reporting things we didn't agree with. Those decisions have since moved into the shared config in v26.1.0 (cloudfour/eslint-config#711), so all four blocks are redundant here. This bumps the dependency and deletes them, leaving `eslint.config.mjs` describing only what is specific to this project — the Cypress and Jest setup.

One difference worth knowing about, since it changes behaviour rather than just moving it: our local rule **required** a two-space indent on wrapped JSDoc lines, while the shared config **permits** either style (`disableWrapIndent` rather than `wrapIndent`). That was a deliberate choice upstream so the release couldn't introduce new errors in any repo. The practical effect here is nil — the existing indentation in `src/index.js` survives `eslint --fix` untouched, which is the behaviour we wanted in the first place.

`unicorn/expiring-todo-comments` is also removed. It turns out the shared config has had that rule off for a long time, so the override was never doing anything. Unrelated to v26.1.0, but it was in the same file.

## Screenshots

## Testing

- [ ] Run `npm run lint:check` — it should pass with no output
- [ ] Run `npm run lint:js` (which applies `--fix`) and then `git status` — no files should be modified. In particular, the indented continuation lines in the `transitionHiddenElement` docblock at the top of `src/index.js` should be left alone rather than flattened
- [ ] Run `npm start`, then in another terminal `npx cypress run` — all 12 specs across the four files should pass
- [ ] With `npm start` still running, open http://localhost:3000 and click **Show**, **Hide** and **Toggle** in each of the four demo sections — each paragraph should fade in and out as its heading describes

---

Follows on from #720
